### PR TITLE
Content with newlines or tabs not to be encoded to base64 in as_xml

### DIFF
--- a/lib/XML/Atom/Content.pm
+++ b/lib/XML/Atom/Content.pm
@@ -147,7 +147,7 @@ sub _is_printable {
           ? $data
           : eval { Encode::decode("utf-8", $data, Encode::FB_CROAK) } );
 
-    return ! $@ && $decoded =~ /^\p{IsPrint}*$/;
+    return ! $@ && $decoded =~ /^[\p{IsPrint}\s]*$/;
 }
 
 1;


### PR DESCRIPTION
in perl >= 5.12.0.
see also https://rt.cpan.org/Public/Bug/Display.html?id=61637
