### PR TITLE
Add dependency on DateTime::TimeZone

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,6 +14,7 @@ requires('XML::XPath');
 requires('LWP::UserAgent');
 requires('Digest::SHA1');
 requires('DateTime');
+requires('DateTime::TimeZone');
 requires('XML::LibXML', 1.69);
 
 features(


### PR DESCRIPTION
Without this dependency listed, bad things happen when deploying stuff that uses XML::Atom::Util, which sometimes uses DateTime::TimeZone in the iso2dt function.
