### PR TITLE
Explicitly add '.' to @INC in Makefile.PL.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,5 +1,6 @@
 # $Id$
 
+use lib '.';
 use inc::Module::Install;
 use 5.008;
 


### PR DESCRIPTION
See https://rt.cpan.org/Public/Bug/Display.html?id=120831

This will be necessary for Perl 5.26.