### PR TITLE
Use Digest::SHA instead of Digest::SHA1

### DIFF
--- a/lib/XML/Atom/Client.pm
+++ b/lib/XML/Atom/Client.pm
@@ -9,7 +9,7 @@ use LWP::UserAgent;
 use XML::Atom::Entry;
 use XML::Atom::Feed;
 use XML::Atom::Util qw( first textValue );
-use Digest::SHA1 qw( sha1 );
+use Digest::SHA qw( sha1 );
 use MIME::Base64 qw( encode_base64 );
 use DateTime;
 

--- a/lib/XML/Atom/Server.pm
+++ b/lib/XML/Atom/Server.pm
@@ -6,7 +6,7 @@ use strict;
 use XML::Atom;
 use base qw( XML::Atom::ErrorHandler );
 use MIME::Base64 qw( encode_base64 decode_base64 );
-use Digest::SHA1 qw( sha1 );
+use Digest::SHA qw( sha1 );
 use XML::Atom::Util qw( first encode_xml textValue );
 use XML::Atom::Entry;
 


### PR DESCRIPTION
Digest::SHA is part of the standard perl distribution since perl v5.9.3
so this reduces the number of external dependencies by one.

(This should fix RT#105308 and RT#60263)