### PR TITLE
Override namespace_uri method only when XML::XPath is too old

### DIFF
--- a/lib/XML/Atom.pm
+++ b/lib/XML/Atom.pm
@@ -19,17 +19,19 @@ BEGIN {
     } else {
         *{XML::Atom::DATETIME} = sub() {0};
     }
-    
-    local $^W = 0;
-    *XML::XPath::Function::namespace_uri = sub {
-        my $self = shift;
-        my($node, @params) = @_;
-        my $ns = $node->getNamespace($node->getPrefix);
-        if (!$ns) {
-            $ns = ($node->getNamespaces)[0];
-        }
-        XML::XPath::Literal->new($ns ? $ns->getExpanded : '');
-    };
+
+    if (!LIBXML() && XML::XPath->VERSION < 1.20) {
+        local $^W = 0;
+        *XML::XPath::Function::namespace_uri = sub {
+            my $self = shift;
+            my($node, @params) = @_;
+            my $ns = $node->getNamespace($node->getPrefix);
+            if (!$ns) {
+                $ns = ($node->getNamespaces)[0];
+            }
+            XML::XPath::Literal->new($ns ? $ns->getExpanded : '');
+        };
+    }
 
     $XML::Atom::ForceUnicode = 0;
     $XML::Atom::DefaultVersion = 0.3;


### PR DESCRIPTION
Since XML::XPath 1.20 and later implements `namespace_uri` method properly, we no longer need to override the method.

Fixes #21 