### PR TITLE
Fix test with external entities

### DIFF
--- a/t/31-external-entities-libxml.t
+++ b/t/31-external-entities-libxml.t
@@ -50,7 +50,7 @@ EOX
 
 ## custom parser
 {
-    my $libxml = XML::LibXML->new;
+    my $libxml = XML::LibXML->new(expand_entities => 1);
     my $entry = XML::Atom::Entry->new(Stream => \$xml, Parser => $libxml);
     is $entry->title, "Guest Author", "got title";
     my $content = $entry->content->body;


### PR DESCRIPTION
`XML::LibXML` stopped expanding entities by default so we have to allow expanding entities explicitly in the test.

https://metacpan.org/changes/distribution/XML-LibXML

> ```
> 2.0202  2020-01-13
>    - Disable loading external DTDs or external entities by default
> ```